### PR TITLE
Hint for reverse trick: make icons look like button

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -237,6 +237,8 @@ Icons take the name of a [material icon](https://design.google.com/icons/) as a 
 
 > You can override Material icons with one of the following: [font-awesome](http://fontawesome.io/icons/), [octicon](https://octicons.github.com/), [ionicon](http://ionicons.com/), [foundation](http://zurb.com/playground/foundation-icon-fonts-3), [evilicon](http://evil-icons.io/), [zocial](http://weloveiconfonts.com/), or [entypo](http://www.entypo.com/) by providing a type prop.
 
+> Hint: use **reverse** to make your icon look like a button
+
 ```js
 
 import { Icon } from 'react-native-elements'


### PR DESCRIPTION
It didn't sound really obvious to me that in order to use "Icon Buttons" as stated in the title of the section we have to put "reverse" as a props to the Icon component.

In fact, I had to try all samples to understand that, so it might be the case for others too.