### PR TITLE
Activity Indicator on Button Element Issue

### DIFF
--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -15,7 +15,7 @@ const Button = ({
   Component,
   disabled,
   loading,
-  loadingLeft,
+  loadingRight,
   activityIndicatorStyle,
   buttonStyle,
   borderRadius,
@@ -127,7 +127,7 @@ const Button = ({
           icon && !iconRight && iconElement
         }
         {
-            loading && !loadingLeft && loadingElement
+            loading && !loadingRight && loadingElement
         }
         <Text
           style={[
@@ -142,7 +142,7 @@ const Button = ({
           {title}
         </Text>
         {
-            loading && loadingLeft && loadingElement
+            loading && loadingRight && loadingElement
         }
         {
           icon && iconRight && iconElement
@@ -172,7 +172,7 @@ Button.propTypes = {
   disabled: PropTypes.bool,
   loading: PropTypes.bool,
   activityIndicatorStyle: PropTypes.any,
-  loadingLeft: PropTypes.bool
+  loadingRight: PropTypes.bool
 }
 
 styles = StyleSheet.create({

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -127,7 +127,7 @@ const Button = ({
           icon && !iconRight && iconElement
         }
         {
-            loading && !loadingRight && loadingElement
+          loading && !loadingRight && loadingElement
         }
         <Text
           style={[
@@ -142,7 +142,7 @@ const Button = ({
           {title}
         </Text>
         {
-            loading && loadingRight && loadingElement
+          loading && loadingRight && loadingElement
         }
         {
           icon && iconRight && iconElement

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -170,7 +170,9 @@ Button.propTypes = {
   raised: PropTypes.bool,
   textStyle: PropTypes.any,
   disabled: PropTypes.bool,
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  activityIndicatorStyle: PropTypes.any,
+  loadingLeft: PropTypes.bool
 }
 
 styles = StyleSheet.create({

--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react'
-import { TouchableWithoutFeedback, TouchableNativeFeedback, TouchableOpacity, TouchableHighlight, StyleSheet, View, Platform } from 'react-native'
+import { TouchableWithoutFeedback, TouchableNativeFeedback, TouchableOpacity, TouchableHighlight, StyleSheet, View, Platform, ActivityIndicator } from 'react-native'
 import colors from '../config/colors'
 import Text from '../text/Text'
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons'
@@ -14,6 +14,9 @@ const log = () => {
 const Button = ({
   Component,
   disabled,
+  loading,
+  loadingLeft,
+  activityIndicatorStyle,
   buttonStyle,
   borderRadius,
   title,
@@ -68,6 +71,17 @@ const Button = ({
         name={icon.name} />
     )
   }
+  let loadingElement;
+  if(loading){
+    loadingElement = (
+      <ActivityIndicator
+        animating={true}
+        style={[styles.activityIndicatorStyle, activityIndicatorStyle]}
+        color={color || "white"}
+        size={small && "small" || "large"}
+      />
+    )
+  }
   if (!Component && Platform.OS === 'ios') {
     Component = TouchableHighlight
   }
@@ -112,6 +126,9 @@ const Button = ({
         {
           icon && !iconRight && iconElement
         }
+        {
+            loading && !loadingLeft && loadingElement
+        }
         <Text
           style={[
             styles.text,
@@ -124,6 +141,9 @@ const Button = ({
           ]}>
           {title}
         </Text>
+        {
+            loading && loadingLeft && loadingElement
+        }
         {
           icon && iconRight && iconElement
         }
@@ -149,7 +169,8 @@ Button.propTypes = {
   underlayColor: PropTypes.string,
   raised: PropTypes.bool,
   textStyle: PropTypes.any,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  loading: PropTypes.bool
 }
 
 styles = StyleSheet.create({
@@ -177,6 +198,10 @@ styles = StyleSheet.create({
   },
   smallFont: {
     fontSize: 14
+  },
+  activityIndicatorStyle: {
+    marginHorizontal: 10,
+    height: 0
   },
   raised: {
     ...Platform.select({

--- a/src/social/SocialIcon.js
+++ b/src/social/SocialIcon.js
@@ -1,9 +1,13 @@
 import React, { PropTypes } from 'react'
-import { View, StyleSheet, Platform, TouchableHighlight } from 'react-native'
+import { View, StyleSheet, Platform, TouchableHighlight, ActivityIndicator } from 'react-native'
 import Icon from 'react-native-vector-icons/FontAwesome'
 import Text from '../text/Text'
 import fonts from '../config/fonts'
 let styles
+
+const log = () => {
+  console.log('please attach method to this component')
+}
 
 const colors = {
   facebook: '#3b5998',
@@ -33,6 +37,10 @@ const SocialIcon = ({
   component,
   type,
   button,
+  disabled,
+  loading,
+  activityIndicatorStyle,
+  small,
   onPress,
   iconStyle,
   style,
@@ -45,11 +53,23 @@ const SocialIcon = ({
   iconSize,
   fontWeight
 }) => {
-  const Component = !onPress ? View : component || TouchableHighlight
+  const Component = !onPress ? View : component || TouchableHighlight;
+  let loadingElement;
+  if(loading){
+    loadingElement = (
+      <ActivityIndicator
+        animating={true}
+        style={[styles.activityIndicatorStyle, activityIndicatorStyle]}
+        color={iconColor || "white"}
+        size={small && "small" || "large"}
+      />
+    )
+  }
   return (
     <Component
       underlayColor={light ? 'white' : colors[type]}
-      onPress={onPress}
+      onPress={(!disabled || log) && (onPress || log)}
+      disabled={disabled || false}
       style={[
         raised && styles.raised,
         styles.container,
@@ -82,6 +102,9 @@ const SocialIcon = ({
               ]}>{title}</Text>
           )
         }
+        {
+            loading && loadingElement
+        }
       </View>
     </Component>
   )
@@ -97,6 +120,10 @@ SocialIcon.propTypes = {
   iconColor: PropTypes.string,
   title: PropTypes.string,
   raised: PropTypes.bool,
+  disabled: PropTypes.bool,
+  loading: PropTypes.bool,
+  activityIndicatorStyle: PropTypes.any,
+  small: PropTypes.string,
   iconSize: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number
@@ -155,7 +182,11 @@ styles = StyleSheet.create({
   icon: {
     height: 52,
     width: 52
-  }
+  },
+  activityIndicatorStyle: {
+    marginHorizontal: 10,
+    height: 0
+  },
 })
 
 export default SocialIcon


### PR DESCRIPTION
**Issue** #56 
Accepts the following new props. 
-   **loading**: PropTypes.bool
-   **activityIndicatorStyle**: PropTypes.any
-   **loadingLeft**: PropTypes.bool

By default the activityIndicator shows up on the right side
It also uses the small prop from the button