### PR TITLE
Fix styling prop for ButtonGroup

### DIFF
--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -23,7 +23,7 @@ const ButtonGroup = ({
 }) => {
   const Component = component || TouchableHighlight
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, containerStyle && containerStyle]}>
       {
         buttons.map((button, i) => {
           return (
@@ -39,7 +39,6 @@ const ButtonGroup = ({
                 styles.button,
                 i < buttons.length - 1 && styles.borderRight,
                 i < buttons.length - 1 && borderStyle && borderStyle,
-                containerStyle && containerStyle,
                 selectedIndex === i && {backgroundColor: selectedBackgroundColor || 'white'}
               ]}>
               <View style={{flex: 1}}>


### PR DESCRIPTION
The `containerStyle` should style the border around button group according to the documentation.
> containerStyle	inherited styling	object (style)	specify styling for main button container (optional)
It doesn't work, because it's on component and there is no other way to change the border's color.
