### PR TITLE
Pass onButtonPress prop to PricingCard Component

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -856,6 +856,7 @@ import { PricingCard } from 'react-native-elements'
 | color | none | string | color scheme for button & title (required) |
 | info | none | array of strings | pricing information (optional) |
 | button | none | object {title, icon, buttonStyle} | button information (required) |
+| onButtonPress | none | any | function to be run when button is pressed |
 | containerStyle | inherited styling | object (style) | outer component styling (optional) |
 | wrapperStyle | inherited styling | object (style) | inner wrapper component styling (optional) |
 | titleFont | System font (font weight 800) (iOS), Roboto-Black (android) | string | specify title font family |

--- a/src/pricing/PricingCard.js
+++ b/src/pricing/PricingCard.js
@@ -19,7 +19,8 @@ const PricingCard = ({
   titleFont,
   pricingFont,
   infoFont,
-  buttonFont
+  buttonFont,
+  onButtonPress
 }) => (
   <View style={[styles.container, containerStyle && containerStyle]}>
     <View style={[styles.wrapper, wrapperStyle && wrapperStyle]}>
@@ -48,7 +49,9 @@ const PricingCard = ({
           {backgroundColor: color},
           buttonFont && {fontFamily: buttonFont}
         ]}
-        title={button.title} />
+        title={button.title}
+        onPress={onButtonPress}
+         />
     </View>
   </View>
 )
@@ -63,7 +66,8 @@ PricingCard.propTypes = {
   ]),
   info: PropTypes.array,
   button: PropTypes.object,
-  color: PropTypes.string
+  color: PropTypes.string,
+  onButtonPress: PropTypes.any,
 }
 
 PricingCard.defaultProps = {


### PR DESCRIPTION
I noticed when using the PricingCard component that I was unable to pass an onPress function to the component's button. This fixes that! 

Thanks for the great lib.
