### PR TITLE
Fix propTypes for Icon component

### DIFF
--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -72,11 +72,8 @@ Icon.propTypes = {
   underlayColor: PropTypes.string,
   reverse: PropTypes.bool,
   raised: PropTypes.bool,
-  containerStyle: PropTypes.object,
-  iconStyle: PropTypes.oneOfType([
-    PropTypes.object,
-    PropTypes.array
-  ]),
+  containerStyle: PropTypes.any,
+  iconStyle: PropTypes.any,
   onPress: PropTypes.func,
   reverseColor: PropTypes.string
 }


### PR DESCRIPTION
Got a warning when I try to use style created via StyleSheet.create. This PR fixing it.

I also double checked propTypes for rest components - they haven't this issue because all propTypes are correct (equal to PropTypes.any).

Let me know if you have any questions.
