### PR TITLE
ButtonGroup text labels shouldn't force upper case

### DIFF
--- a/src/buttons/ButtonGroup.js
+++ b/src/buttons/ButtonGroup.js
@@ -49,7 +49,7 @@ const ButtonGroup = ({
                     textStyle && textStyle,
                     selectedIndex === i && {color: colors.grey1},
                     selectedIndex === i && selectedTextStyle && selectedTextStyle
-                  ]}>{button.toUpperCase()}</Text>
+                  ]}>{button}</Text>
               </View>
             </Component>
           )


### PR DESCRIPTION
By default, ButtonGroup elements convert the text labels to upper case. Since react native doesn't support text transforms via css styles (and they'd be overwritten anyways by the button.toUpperCase() call, can we not force the upper casing on all text and instead just pass through the initial button text labels?