### PR TITLE
[FIX] add hitSlop to button

### DIFF
--- a/src/buttons/Button.js
+++ b/src/buttons/Button.js
@@ -29,6 +29,7 @@ const Button = ({
   onLongPress,
   onPressIn,
   onPressOut,
+  hitSlop,
   activeOpacity,
   onHideUnderlay,
   onShowUnderlay,
@@ -108,6 +109,7 @@ const Button = ({
       SelectableBackground={SelectableBackground}
       SelectableBackgroundBorderless={SelectableBackgroundBorderless}
       Ripple={Ripple}
+      hitSlop={hitSlop}
       underlayColor={underlayColor || 'transparent'}
       onPress={onPress || log}
       disabled={disabled || false}>


### PR DESCRIPTION
The TouchableWithoutFeedback prop `hitSlop` was missing from button. This adds that.
https://facebook.github.io/react-native/docs/touchablewithoutfeedback.html#props
