### PR TITLE
Fixed #78 Invalid Icon 'component' propType

### DIFF
--- a/src/icons/Icon.js
+++ b/src/icons/Icon.js
@@ -70,7 +70,7 @@ Icon.propTypes = {
   name: PropTypes.string,
   size: PropTypes.number,
   color: PropTypes.string,
-  component: PropTypes.element,
+  component: PropTypes.func,
   underlayColor: PropTypes.string,
   reverse: PropTypes.bool,
   raised: PropTypes.bool,


### PR DESCRIPTION
I think React Native Components are mostly 'func' type. 'element' type returns true if it is constructed using `React.createElement()`.