### PR TITLE
when set image property on card container - throws layout error (fixe…

### DIFF
--- a/src/containers/Card.js
+++ b/src/containers/Card.js
@@ -38,10 +38,10 @@ const Card = ({
       }
       {
         image && (
-          <View style={{flex: 1}}>
+          <View>
             <Image
               resizeMode='cover'
-              style={[{flex:1, width: null, height: 150}, imageStyle && imageStyle]}
+              style={[{width: null, height: 150}, imageStyle && imageStyle]}
               source={image}  />
             <View
               style={[{padding: 10}, wrapperStyle && wrapperStyle]}>


### PR DESCRIPTION
It appears that if parent element don't have style flex:1, but child have (or parent don't have height hard set), the react throws error.

I'm not sure what is the idea about adding flex property here - if I remove it - visually the component looks right - it expands image to full width of the Card element.