### PR TITLE
Update using-with-crna.md -- TTF fonts are recognized by default now

### DIFF
--- a/using-with-crna.md
+++ b/using-with-crna.md
@@ -12,21 +12,6 @@ or
 npm install @expo/vector-icons react-native-elements
 ```
 
-**Note: As of right now there is an issue with create-react-native-app which doesn't recognize .ttf fonts. To fix this do the following. This is only required until [react-community/create-react-native-app#53](https://github.com/react-community/create-react-native-app/issues/53) is fixed**
-
-In app.json add the following
-
-```js
-{
-  "expo": {
-    "sdkVersion": "14.0.0",
-    "packagerOpts": {
-      "assetExts": ["ttf"]
-    }
-  }
-}
-``` 
-
 #### Step 2
 
 Start using the components


### PR DESCRIPTION
The previous asset system issue has been fixed -- CRNA apps created as of last night can now load ttf by default.