### PR TITLE
Add missing save param to the npm install command in CRNA readme

### DIFF
--- a/using-with-crna.md
+++ b/using-with-crna.md
@@ -9,7 +9,7 @@ yarn add @expo/vector-icons react-native-elements
 or
 
 ```
-npm install @expo/vector-icons react-native-elements
+npm install @expo/vector-icons react-native-elements --save
 ```
 
 #### Step 2


### PR DESCRIPTION
Since `yarn add` command adds installed package to project dependencies, we should add a save param to the `npm install` command so they are both equal.