### PR TITLE
Use fontWeight and fontFamily rather than fontFamily for everything

### DIFF
--- a/src/checkbox/CheckBox.js
+++ b/src/checkbox/CheckBox.js
@@ -100,7 +100,7 @@ styles = StyleSheet.create({
         fontWeight: 'bold'
       },
       android: {
-        fontFamily: fonts.android.bold
+        ...fonts.android.bold,
       }
     })
   }

--- a/src/config/fonts.js
+++ b/src/config/fonts.js
@@ -1,14 +1,34 @@
 export default {
-  ios: {
-  },
+  ios: {},
   android: {
-    regular: 'sans-serif',
-    light: 'sans-serif-light',
-    condensed: 'sans-serif-condensed',
-    condensed_light: 'sans-serif-condensed-light',
-    black: 'sans-serif-black',
-    thin: 'sans-serif-thin',
-    medium: 'sans-serif-medium',
-    bold: 'sans-serif-bold',
-  }
-}
+    regular: {
+      fontFamily: 'sans-serif',
+    },
+    light: {
+      fontFamily: 'sans-serif-light',
+    },
+    condensed: {
+      fontFamily: 'sans-serif-condensed',
+    },
+    condensed_light: {
+      fontFamily: 'sans-serif-condensed',
+      fontWeight: 'light',
+    },
+    black: {
+      // note(brentvatne): sans-serif-black is only supported on Android 5+,
+      // we can detect that here and use it in that case at some point.
+      fontFamily: 'sans-serif',
+      fontWeight: 'bold',
+    },
+    thin: {
+      fontFamily: 'sans-serif-thin',
+    },
+    medium: {
+      fontFamily: 'sans-serif-medium',
+    },
+    bold: {
+      fontFamily: 'sans-serif',
+      fontWeight: 'bold',
+    },
+  },
+};

--- a/src/containers/Card.js
+++ b/src/containers/Card.js
@@ -85,7 +85,7 @@ styles = StyleSheet.create({
         fontWeight: '500'
       },
       android: {
-        fontFamily: fonts.android.black
+        ...fonts.android.black
       }
     })
   },
@@ -102,7 +102,7 @@ styles = StyleSheet.create({
         fontWeight: 'bold'
       },
       android: {
-        fontFamily: fonts.android.black
+        ...fonts.android.black
       }
     }),
     textAlign: 'center',

--- a/src/form/FormLabel.js
+++ b/src/form/FormLabel.js
@@ -31,7 +31,7 @@ styles = StyleSheet.create({
         fontWeight: 'bold'
       },
       android: {
-        fontFamily: fonts.android.bold
+        ...fonts.android.bold
       }
     })
   }

--- a/src/list/ListItem.js
+++ b/src/list/ListItem.js
@@ -200,7 +200,7 @@ styles = StyleSheet.create({
         fontWeight: '600'
       },
       android: {
-        fontFamily: fonts.android.bold
+        ...fonts.android.bold
       }
     })
   },

--- a/src/pricing/PricingCard.js
+++ b/src/pricing/PricingCard.js
@@ -106,7 +106,7 @@ styles = StyleSheet.create({
         fontWeight: '800'
       },
       android: {
-        fontFamily: fonts.android.black
+        ...fonts.android.black
       }
     })
   },
@@ -120,7 +120,7 @@ styles = StyleSheet.create({
         fontWeight: '700'
       },
       android: {
-        fontFamily: fonts.android.bold
+        ...fonts.android.bold
       }
     })
   },
@@ -134,7 +134,7 @@ styles = StyleSheet.create({
         fontWeight: '600'
       },
       android: {
-        fontFamily: fonts.android.bold
+        ...fonts.android.bold
       }
     })
   },

--- a/src/social/SocialIcon.js
+++ b/src/social/SocialIcon.js
@@ -178,7 +178,7 @@ styles = StyleSheet.create({
         fontWeight: 'bold'
       },
       android: {
-        fontFamily: fonts.android.black
+        ...fonts.android.black
       }
     })
   },

--- a/src/text/Text.js
+++ b/src/text/Text.js
@@ -26,14 +26,14 @@ styles = StyleSheet.create({
   text: {
     ...Platform.select({
       android: {
-        fontFamily: fonts.android.regular
+        ...fonts.android.regular
       }
     })
   },
   bold: {
     ...Platform.select({
       android: {
-        fontFamily: fonts.android.bold
+        ...fonts.android.bold
       }
     })
   }


### PR DESCRIPTION
It turns out the previous commit almost fixed it but in a few places it was necessary to add fontWeight rather than specify it as fontFamily.