### PR TITLE
ImageWrapperStyle prop for Card component to fix card image flex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1044,6 +1044,7 @@ import { Card, ListItem, Button } from 'react-native-elements'
 | dividerStyle | none | object (style) | additional divider styling (if title provided) (optional) |
 | fontFamily | System font bold (iOS), Sans Serif Bold (android) | string | specify different font family |
 | imageStyle | inherited styling | object(style) | specify image styling if image is provided |
+| imageWrapperStyle | none | object(style) | specify styling for view surrounding image |
 | image | none | image uri or require path | add an image as the heading with the image prop (optional) |
 
 

--- a/src/containers/Card.js
+++ b/src/containers/Card.js
@@ -13,6 +13,7 @@ const Card = ({
   flexDirection,
   containerStyle,
   wrapperStyle,
+  imageWrapperStyle,
   title,
   titleStyle,
   dividerStyle,
@@ -38,7 +39,7 @@ const Card = ({
       }
       {
         image && (
-          <View>
+          <View style={imageWrapperStyle && imageWrapperStyle}>
             <Image
               resizeMode='cover'
               style={[{width: null, height: 150}, imageStyle && imageStyle]}


### PR DESCRIPTION
Fixes the bug introduced in commit #200 where we are no longer able to set flex for image and wrapper, as the parent View component has no flexbox. With this, a style of `{flex: 1}` can once again be set on the View. 

Addresses issue #259